### PR TITLE
fix(posts): correct /posts GET handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,8 @@ func deletePost(w http.ResponseWriter, r *http.Request) {
 func main() {
   router := mux.NewRouter()
   posts = append(posts, Post{ID: "1", Title: "My first post", Body: "This is the content of my first post"})
-  router.HandleFunc("/posts", createPost).Methods("GET")
+-  router.HandleFunc("/posts", createPost).Methods("GET")
++  router.HandleFunc("/posts", getPosts).Methods("GET")
   router.HandleFunc("/posts", createPost).Methods("POST")
   router.HandleFunc("/posts/{id}", getPost).Methods("GET")
   router.HandleFunc("/posts/{id}", updatePost).Methods("PUT")


### PR DESCRIPTION
Summary:
The GET /posts endpoint was incorrectly mapped to createPost handler, causing GET requests to create new posts instead of returning the list.

Root Cause:
Router.HandleFunc paired /posts GET with createPost instead of getPosts.

What Changed:
Updated router mapping: changed GET /posts to call getPosts.

Why:
To return the posts list on GET rather than mutate state.

How to Test Manually:
1) Start server: go run main.go
2) Existing post response:
   curl -i http://localhost:8000/posts
   Expect HTTP/1.1 200 OK and JSON array with initial post.
3) Ensure GET does not create posts:
   curl -i http://localhost:8000/posts && curl -i http://localhost:8000/posts
   Count stays constant.

Risk and Rollback:
Low risk; only route mapping changed. Rolling back is removing the new branch or restoring the original mapping.