### PR TITLE
fix: DOP-4028 - Lambda support for Data team

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,4 +1,5 @@
 package main
+
 import (
   "github.com/gorilla/mux"
   "net/http"
@@ -12,6 +13,7 @@ type Post struct {
   Title string `json:"title"`
   Body string `json:"body"`
 }
+
 var posts []Post
 
 func getPosts(w http.ResponseWriter, r *http.Request) {
@@ -24,7 +26,7 @@ func createPost(w http.ResponseWriter, r *http.Request) {
   var post Post
   err := json.NewDecoder(r.Body).Decode(&post)
   if err != nil{
-  	panic(err)
+    panic(err)
   }
   post.ID = strconv.Itoa(rand.Intn(1000000))
   posts = append(posts, post)
@@ -75,7 +77,7 @@ func deletePost(w http.ResponseWriter, r *http.Request) {
 func main() {
   router := mux.NewRouter()
   posts = append(posts, Post{ID: "1", Title: "My first post", Body: "This is the content of my first post"})
-  router.HandleFunc("/posts", createPost).Methods("GET")
+  router.HandleFunc("/posts", getPosts).Methods("GET")
   router.HandleFunc("/posts", createPost).Methods("POST")
   router.HandleFunc("/posts/{id}", getPost).Methods("GET")
   router.HandleFunc("/posts/{id}", updatePost).Methods("PUT")


### PR DESCRIPTION
Summary:
Fixed incorrect handler mapping for GET /posts request which was previously wired to createPost. Root cause was the wrong function reference in router.HandleFunc.

Changes:
- Updated router.HandleFunc("/posts", getPosts).Methods("GET") to correctly register the GET handler.

Testing:
1. Run the server: go run main.go
2. GET posts: curl http://localhost:8000/posts
   - Should return JSON array of posts
3. POST a new post: curl -X POST -d '{"title":"Test","body":"Body"}' -H "Content-Type: application/json" http://localhost:8000/posts
   - Should return created post JSON

Risk:
Low - only routing configuration was updated. Rollback by reverting commit in branch.